### PR TITLE
CORE-7221: Add labels to images denoting git-refs

### DIFF
--- a/docker/backwards-compat/Dockerfile
+++ b/docker/backwards-compat/Dockerfile
@@ -1185,3 +1185,6 @@ ENV PATH=/usr/kerberos/bin:/usr/local2/icommands:/usr/local2/bin:/usr/local/sbin
     irodsEnvFile=/root/.irods/.irodsEnv
 VOLUME ["/usr/local2/", "/usr/local3/", "/data2/", "/condor01/"]
 CMD ["/bin/bash"]
+
+ARG git_commit=unknown
+LABEL org.iplantc.de.backwards-compat.git-ref="$git_commit"

--- a/docker/de-backend-buildenv/Dockerfile
+++ b/docker/de-backend-buildenv/Dockerfile
@@ -1,5 +1,7 @@
 FROM centos:centos7
 MAINTAINER John Wregglesworth <wregglej@gmail.com>
+ARG git_commit
+LABEL org.iplantc.de.buildenv.git-ref="$git_commit"
 
 ENV GOOS=linux GOARCH=amd64 GOVERSION=1.5
 ENV MVNVERSION=3.3.3
@@ -50,6 +52,5 @@ RUN npm install -g grunt-cli
 RUN lein help
 RUN git clone https://github.com/iPlantCollaborativeOpenSource/DE.git backend && \
     cd backend && \
-    git checkout %%GIT_COMMIT%% && \
+    git checkout $git_commit && \
     lein exec build-all.clj lein-plugins libs
-LABEL org.iplantc.de.buildenv.git-ref="%%GIT_COMMIT%%"

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -4,12 +4,5 @@ set -e
 
 GIT_COMMIT=$(git rev-parse HEAD)
 
-if [ -f Dockerfile.template ]
-then
-  sed -e "s/%%GIT_COMMIT%%/$GIT_COMMIT/g" Dockerfile.template > Dockerfile.$GIT_COMMIT
-  docker build --pull --no-cache --rm -t "$DOCKER_USER/$DOCKER_REPO:latest" -f Dockerfile.$GIT_COMMIT .
-  rm Dockerfile.$GIT_COMMIT
-else
-  docker build --pull --no-cache --rm -t "$DOCKER_USER/$DOCKER_REPO:latest" .
-fi
+docker build --build-arg git_commit=$GIT_COMMIT --pull --no-cache --rm -t "$DOCKER_USER/$DOCKER_REPO:latest" .
 docker push $DOCKER_USER/$DOCKER_REPO:latest

--- a/docker/javabase/Dockerfile
+++ b/docker/javabase/Dockerfile
@@ -1,5 +1,7 @@
 FROM jeanblanchard/java:8
 MAINTAINER Ian McEwen <mian@iplantcollaborative.org>
+ARG git_commit=unknown
+LABEL org.iplantc.de.javabase.git-ref="$git_commit"
 
 RUN apk add --update curl \
     && mkdir -p /tmp/jce \
@@ -17,4 +19,3 @@ USER iplant
 RUN mkdir -p /home/iplant/logs/
 WORKDIR /home/iplant
 EXPOSE 60000
-LABEL org.iplantc.de.javabase.git-ref="%%GIT_COMMIT%%"

--- a/services/Infosquito/Dockerfile
+++ b/services/Infosquito/Dockerfile
@@ -9,7 +9,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.infosquito.git-ref="$git_commit" \
+      org.iplantc.de.infosquito.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/Infosquito/Dockerfile
+++ b/services/Infosquito/Dockerfile
@@ -7,6 +7,11 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/infosquito-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.infosquito.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/infosquito-logging.xml", "-cp", ".:infosquito-standalone.jar", "infosquito.core"]
 CMD ["--help"]

--- a/services/JEX/Dockerfile
+++ b/services/JEX/Dockerfile
@@ -2,7 +2,9 @@ FROM java:8
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.jex.git-ref="$git_commit" \
+      org.iplantc.de.jex.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 COPY target/jex-standalone.jar /jex-standalone.jar

--- a/services/JEX/Dockerfile
+++ b/services/JEX/Dockerfile
@@ -1,5 +1,10 @@
 FROM java:8
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.jex.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 COPY target/jex-standalone.jar /jex-standalone.jar
 COPY conf/main/logback.xml /logback.xml
 COPY submitnerator.sh /submitnerator.sh

--- a/services/NotificationAgent/Dockerfile
+++ b/services/NotificationAgent/Dockerfile
@@ -7,6 +7,11 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/notificationagent-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.notificationagent.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/notificationagent-logging.xml", "-cp", ".:notificationagent-standalone.jar", "notification_agent.core"]
 CMD ["--help"]

--- a/services/NotificationAgent/Dockerfile
+++ b/services/NotificationAgent/Dockerfile
@@ -9,7 +9,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.notificationagent.git-ref="$git_commit" \
+      org.iplantc.de.notificationagent.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/anon-files/Dockerfile
+++ b/services/anon-files/Dockerfile
@@ -7,5 +7,10 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/anon-files-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.anon-files.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/anon-files-logging.xml", "-cp", ".:anon-files-standalone.jar", "anon_files.core"]

--- a/services/anon-files/Dockerfile
+++ b/services/anon-files/Dockerfile
@@ -9,7 +9,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.anon-files.git-ref="$git_commit" \
+      org.iplantc.de.anon-files.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/apps/Dockerfile
+++ b/services/apps/Dockerfile
@@ -16,7 +16,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.apps.git-ref="$git_commit" \
+      org.iplantc.de.apps.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/apps/Dockerfile
+++ b/services/apps/Dockerfile
@@ -14,6 +14,11 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/apps-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.apps.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/apps-logging.xml", "-cp", ".:apps-standalone.jar:/home/iplant/", "apps.core"]
 CMD ["--help"]

--- a/services/clockwork/Dockerfile
+++ b/services/clockwork/Dockerfile
@@ -9,7 +9,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.clockwork.git-ref="$git_commit" \
+      org.iplantc.de.clockwork.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/clockwork/Dockerfile
+++ b/services/clockwork/Dockerfile
@@ -7,5 +7,10 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/clockwork-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.clockwork.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/clockwork-logging.xml", "-cp", ".:clockwork-standalone.jar", "clockwork.core"]

--- a/services/condor-log-monitor/Dockerfile
+++ b/services/condor-log-monitor/Dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:14.04
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.condor-log-monitor.git-ref="$git_commit" \
+      org.iplantc.de.condor-log-monitor.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 RUN useradd -m -U -s /bin/bash iplant

--- a/services/condor-log-monitor/Dockerfile
+++ b/services/condor-log-monitor/Dockerfile
@@ -1,5 +1,10 @@
 FROM ubuntu:14.04
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.condor-log-monitor.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 RUN useradd -m -U -s /bin/bash iplant
 ADD bin/condor-log-monitor /bin/
 USER iplant

--- a/services/data-info/Dockerfile
+++ b/services/data-info/Dockerfile
@@ -7,6 +7,11 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/data-info-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.data-info.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/data-info-logging.xml", "-cp", ".:data-info-standalone.jar", "data_info.core"]
 CMD ["--help"]

--- a/services/data-info/Dockerfile
+++ b/services/data-info/Dockerfile
@@ -9,7 +9,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.data-info.git-ref="$git_commit" \
+      org.iplantc.de.data-info.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/dewey/Dockerfile
+++ b/services/dewey/Dockerfile
@@ -9,7 +9,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.dewey.git-ref="$git_commit" \
+      org.iplantc.de.dewey.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/dewey/Dockerfile
+++ b/services/dewey/Dockerfile
@@ -7,6 +7,11 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/dewey-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.dewey.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/dewey-logging.xml", "-cp", ".:dewey-standalone.jar", "dewey.core"]
 CMD ["--help"]

--- a/services/docker-build.sh
+++ b/services/docker-build.sh
@@ -10,6 +10,9 @@ docker pull $DOCKER_USER/buildenv:latest
 BUILDENV_GIT_COMMIT=$(docker inspect -f '{{ (index .Config.Labels "org.iplantc.de.buildenv.git-ref")}}' $DOCKER_USER/buildenv:latest)
 
 docker run --rm -e "GIT_COMMIT=$GIT_COMMIT" -v $(pwd):/build -w /build $DOCKER_USER/buildenv lein uberjar
-docker build --build-arg git_commit=$GIT_COMMIT --build-arg buildenv_git_commit=$BUILDENV_GIT_COMMIT --pull --rm -t "$DOCKER_USER/$DOCKER_REPO:dev" .
+docker build --build-arg git_commit=$GIT_COMMIT \
+             --build-arg buildenv_git_commit=$BUILDENV_GIT_COMMIT \
+             --build-arg version=$VERSION \
+             --pull --rm -t "$DOCKER_USER/$DOCKER_REPO:dev" .
 docker push $DOCKER_USER/$DOCKER_REPO:dev
 docker rmi $DOCKER_USER/$DOCKER_REPO:dev

--- a/services/docker-build.sh
+++ b/services/docker-build.sh
@@ -10,15 +10,6 @@ docker pull $DOCKER_USER/buildenv:latest
 BUILDENV_GIT_COMMIT=$(docker inspect -f '{{ (index .Config.Labels "org.iplantc.de.buildenv.git-ref")}}' $DOCKER_USER/buildenv:latest)
 
 docker run --rm -e "GIT_COMMIT=$GIT_COMMIT" -v $(pwd):/build -w /build $DOCKER_USER/buildenv lein uberjar
-if [ -f Dockerfile.template ]
-then
-  sed -e "s/%%GIT_COMMIT%%/$GIT_COMMIT/g" \
-      -e "s/%%BUILDENV_GIT_COMMIT%%/$BUILDENV_GIT_COMMIT/g" \
-      Dockerfile.template > Dockerfile.$GIT_COMMIT
-  docker build --pull --rm -t "$DOCKER_USER/$DOCKER_REPO:dev" -f Dockerfile.$GIT_COMMIT .
-  rm Dockerfile.$GIT_COMMIT
-else
-  docker build --pull --rm -t "$DOCKER_USER/$DOCKER_REPO:dev" .
-fi
+docker build --build-arg git_commit=$GIT_COMMIT --build-arg buildenv_git_commit=$BUILDENV_GIT_COMMIT --pull --rm -t "$DOCKER_USER/$DOCKER_REPO:dev" .
 docker push $DOCKER_USER/$DOCKER_REPO:dev
 docker rmi $DOCKER_USER/$DOCKER_REPO:dev

--- a/services/info-typer/Dockerfile
+++ b/services/info-typer/Dockerfile
@@ -7,6 +7,11 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/info-typer-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.info-typer.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/info-typer-logging.xml", "-cp", ".:info-typer-standalone.jar", "info_typer.core"]
 CMD ["--help"]

--- a/services/info-typer/Dockerfile
+++ b/services/info-typer/Dockerfile
@@ -9,7 +9,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.info-typer.git-ref="$git_commit" \
+      org.iplantc.de.info-typer.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/iplant-email/Dockerfile
+++ b/services/iplant-email/Dockerfile
@@ -10,7 +10,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.iplant-email.git-ref="$git_commit" \
+      org.iplantc.de.iplant-email.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/iplant-email/Dockerfile
+++ b/services/iplant-email/Dockerfile
@@ -8,6 +8,11 @@ COPY conf/*.st /home/iplant/
 COPY target/iplant-email-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.iplant-email.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/iplant-email-logging.xml", "-cp", ".:iplant-email-standalone.jar", "iplant_email.core"]
 CMD ["--help"]

--- a/services/iplant-groups/Dockerfile
+++ b/services/iplant-groups/Dockerfile
@@ -7,6 +7,11 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/iplant-groups-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.iplant-groups.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/iplant-groups-logging.xml", "-cp", ".:iplant-groups-standalone.jar:/home/iplant/", "iplant_groups.core"]
 CMD ["--help"]

--- a/services/iplant-groups/Dockerfile
+++ b/services/iplant-groups/Dockerfile
@@ -9,7 +9,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.iplant-groups.git-ref="$git_commit" \
+      org.iplantc.de.iplant-groups.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/jex-events/Dockerfile
+++ b/services/jex-events/Dockerfile
@@ -2,6 +2,12 @@ FROM ubuntu:14.04
 
 RUN useradd -m -U -s /bin/bash iplant
 ADD bin/jex-events /bin/
+
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.jex-events.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 RUN mkdir -p /home/iplant/logs/
 WORKDIR /home/iplant

--- a/services/jex-events/Dockerfile
+++ b/services/jex-events/Dockerfile
@@ -5,7 +5,9 @@ ADD bin/jex-events /bin/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.jex-events.git-ref="$git_commit" \
+      org.iplantc.de.jex-events.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/kifshare/Dockerfile
+++ b/services/kifshare/Dockerfile
@@ -10,7 +10,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.kifshare.git-ref="$git_commit" \
+      org.iplantc.de.kifshare.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/kifshare/Dockerfile
+++ b/services/kifshare/Dockerfile
@@ -8,6 +8,11 @@ COPY build/* /home/iplant/resources/
 COPY target/kifshare-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.kifshare.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/kifshare-logging.xml", "-cp", ".:resources:kifshare-standalone.jar", "kifshare.core"]
 CMD ["--help"]

--- a/services/metadata/Dockerfile
+++ b/services/metadata/Dockerfile
@@ -7,6 +7,11 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/metadata-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.metadata.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/metadata-logging.xml", "-cp", ".:metadata-standalone.jar:/home/iplant/", "metadata.core"]
 CMD ["--help"]

--- a/services/metadata/Dockerfile
+++ b/services/metadata/Dockerfile
@@ -9,7 +9,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.metadata.git-ref="$git_commit" \
+      org.iplantc.de.metadata.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/monkey/Dockerfile
+++ b/services/monkey/Dockerfile
@@ -9,7 +9,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.monkey.git-ref="$git_commit" \
+      org.iplantc.de.monkey.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/monkey/Dockerfile
+++ b/services/monkey/Dockerfile
@@ -7,6 +7,11 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/monkey-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.monkey.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/monkey-logging.xml", "-cp", ".:monkey-standalone.jar", "monkey.core"]
 CMD ["--help"]

--- a/services/saved-searches/Dockerfile
+++ b/services/saved-searches/Dockerfile
@@ -9,7 +9,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.saved-searches.git-ref="$git_commit" \
+      org.iplantc.de.saved-searches.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/saved-searches/Dockerfile
+++ b/services/saved-searches/Dockerfile
@@ -7,6 +7,11 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/saved-searches-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.saved-searches.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/saved-searches-logging.xml", "-cp", ".:saved-searches-standalone.jar", "saved_searches.core"]
 CMD ["--help"]

--- a/services/terrain/Dockerfile
+++ b/services/terrain/Dockerfile
@@ -14,6 +14,11 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/terrain-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.terrain.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/terrain-logging.xml", "-cp", ".:terrain-standalone.jar", "terrain.core"]
 CMD ["--help"]

--- a/services/terrain/Dockerfile
+++ b/services/terrain/Dockerfile
@@ -16,7 +16,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.terrain.git-ref="$git_commit" \
+      org.iplantc.de.terrain.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/tree-urls/Dockerfile
+++ b/services/tree-urls/Dockerfile
@@ -9,7 +9,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.tree-urls.git-ref="$git_commit" \
+      org.iplantc.de.tree-urls.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/tree-urls/Dockerfile
+++ b/services/tree-urls/Dockerfile
@@ -7,6 +7,11 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/tree-urls-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.tree-urls.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/tree-urls-logging.xml", "-cp", ".:tree-urls-standalone.jar", "tree_urls.core"]
 CMD ["--help"]

--- a/services/user-preferences/Dockerfile
+++ b/services/user-preferences/Dockerfile
@@ -9,7 +9,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.user-preferences.git-ref="$git_commit" \
+      org.iplantc.de.user-preferences.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/services/user-preferences/Dockerfile
+++ b/services/user-preferences/Dockerfile
@@ -7,6 +7,11 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/user-preferences-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.user-preferences.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/user-preferences-logging.xml", "-cp", ".:user-preferences-standalone.jar", "user_preferences.core"]
 CMD ["--help"]

--- a/services/user-sessions/Dockerfile
+++ b/services/user-sessions/Dockerfile
@@ -7,6 +7,11 @@ COPY conf/main/logback.xml /home/iplant/
 COPY target/user-sessions-standalone.jar /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.user-sessions.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/user-sessions-logging.xml", "-cp", ".:user-sessions-standalone.jar", "user_sessions.core"]
 CMD ["--help"]

--- a/services/user-sessions/Dockerfile
+++ b/services/user-sessions/Dockerfile
@@ -9,7 +9,9 @@ RUN chown -R iplant:iplant /home/iplant/
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.user-sessions.git-ref="$git_commit" \
+      org.iplantc.de.user-sessions.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant

--- a/tools/docker-build.sh
+++ b/tools/docker-build.sh
@@ -2,6 +2,7 @@
 set -x
 set -e
 
+VERSION=$(cat version | sed -e 's/^ *//' -e 's/ *$//')
 GIT_COMMIT=$(git rev-parse HEAD)
 
 docker pull $DOCKER_USER/buildenv:latest
@@ -9,5 +10,8 @@ docker pull $DOCKER_USER/buildenv:latest
 BUILDENV_GIT_COMMIT=$(docker inspect -f '{{ (index .Config.Labels "org.iplantc.de.buildenv.git-ref")}}' $DOCKER_USER/buildenv:latest)
 
 docker run --rm -e "GIT_COMMIT=$GIT_COMMIT" -v $(pwd):/build -w /build $DOCKER_USER/buildenv:latest lein uberjar
-docker build --build-arg git_commit=$GIT_COMMIT --build-arg buildenv_git_commit=$BUILDENV_GIT_COMMIT --pull --rm -t "$DOCKER_USER/$DOCKER_REPO:dev" .
+docker build --build-arg git_commit=$GIT_COMMIT \
+             --build-arg buildenv_git_commit=$BUILDENV_GIT_COMMIT \
+             --build-arg version=$VERSION \
+             --pull --rm -t "$DOCKER_USER/$DOCKER_REPO:dev" .
 docker push $DOCKER_USER/$DOCKER_REPO:dev

--- a/tools/docker-build.sh
+++ b/tools/docker-build.sh
@@ -9,14 +9,5 @@ docker pull $DOCKER_USER/buildenv:latest
 BUILDENV_GIT_COMMIT=$(docker inspect -f '{{ (index .Config.Labels "org.iplantc.de.buildenv.git-ref")}}' $DOCKER_USER/buildenv:latest)
 
 docker run --rm -e "GIT_COMMIT=$GIT_COMMIT" -v $(pwd):/build -w /build $DOCKER_USER/buildenv:latest lein uberjar
-if [ -f Dockerfile.template ]
-then
-  sed -e "s/%%GIT_COMMIT%%/$GIT_COMMIT/g" \
-      -e "s/%%BUILDENV_GIT_COMMIT%%/$BUILDENV_GIT_COMMIT/g" \
-      Dockerfile.template > Dockerfile.$GIT_COMMIT
-  docker build --pull --rm -t "$DOCKER_USER/$DOCKER_REPO:dev" -f Dockerfile.$GIT_COMMIT .
-  rm Dockerfile.$GIT_COMMIT
-else
-  docker build --pull --rm -t "$DOCKER_USER/$DOCKER_REPO:dev" .
-fi
+docker build --build-arg git_commit=$GIT_COMMIT --build-arg buildenv_git_commit=$BUILDENV_GIT_COMMIT --pull --rm -t "$DOCKER_USER/$DOCKER_REPO:dev" .
 docker push $DOCKER_USER/$DOCKER_REPO:dev

--- a/tools/facepalm/Dockerfile
+++ b/tools/facepalm/Dockerfile
@@ -12,7 +12,9 @@ RUN apt-get update && apt-get install -y \
 
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.facepalm.git-ref="$git_commit" \
+      org.iplantc.de.facepalm.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 COPY target/facepalm-standalone.jar /

--- a/tools/facepalm/Dockerfile
+++ b/tools/facepalm/Dockerfile
@@ -10,6 +10,11 @@ RUN apt-get update && apt-get install -y \
   postgresql-client-9.3 \
   && rm -rf /var/lib/apt/lists/*
 
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.facepalm.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 COPY target/facepalm-standalone.jar /
 
 ENTRYPOINT ["java", "-jar", "facepalm-standalone.jar"]

--- a/tools/filetool/Dockerfile
+++ b/tools/filetool/Dockerfile
@@ -1,4 +1,8 @@
 FROM irods/icommands:4.0.3
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.porklock.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 ADD target/porklock-standalone.jar /porklock-standalone.jar
 

--- a/tools/filetool/Dockerfile
+++ b/tools/filetool/Dockerfile
@@ -1,7 +1,9 @@
 FROM irods/icommands:4.0.3
 ARG git_commit=unknown
 ARG buildenv_git_commit=unknown
+ARG version=unknown
 LABEL org.iplantc.de.porklock.git-ref="$git_commit" \
+      org.iplantc.de.porklock.version="$version" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 ADD target/porklock-standalone.jar /porklock-standalone.jar

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,8 +1,15 @@
 FROM discoenv/javabase
 
-ADD target/de.war /home/iplant/
 USER root
+
+ADD target/de.war /home/iplant/
 RUN chown -R iplant:iplant /home/iplant/
+
+ARG git_commit=unknown
+ARG buildenv_git_commit=unknown
+LABEL org.iplantc.de.ui.git-ref="$git_commit" \
+      org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
+
 USER iplant
 EXPOSE 8080
 

--- a/ui/docker-build.sh
+++ b/ui/docker-build.sh
@@ -29,14 +29,5 @@ docker run --rm -t -a stdout -a stderr \
     -PGIT_COMMIT=${GIT_COMMIT} \
     -PGIT_BRANCH=${GIT_BRANCH} 
 
-if [ -f Dockerfile.template ]
-then
-  sed -e "s/%%GIT_COMMIT%%/$GIT_COMMIT/g" \
-      -e "s/%%BUILDENV_GIT_COMMIT%%/$BUILDENV_GIT_COMMIT/g" \
-      Dockerfile.template > Dockerfile.$GIT_COMMIT
-  docker build --pull --rm -t "$DOCKER_USER/$DOCKER_REPO:dev" -f Dockerfile.$GIT_COMMIT .
-  rm Dockerfile.$GIT_COMMIT
-else
-  docker build --pull --rm -t "$DOCKER_USER/$DOCKER_REPO:dev" .
-fi
+docker build --build-arg git_commit=$GIT_COMMIT --build-arg buildenv_git_commit=$BUILDENV_GIT_COMMIT --pull --rm -t "$DOCKER_USER/$DOCKER_REPO:dev" .
 docker push $DOCKER_USER/$DOCKER_REPO:dev


### PR DESCRIPTION
You'll probably want to look at/review https://github.com/iPlantCollaborativeOpenSource/DE/compare/1bd3f81...eb25c4a (plus https://github.com/iPlantCollaborativeOpenSource/DE/commit/580f48b5181da90aeecab8b3deda57c138e4d614 -- just copying some stuff into the ui build script that's in the first block of commits for tools/services) first/primarily. Those commits set up the structure which the changes in this PR take advantage of, but I've done those first and directly to dev so that the baseIf images already have label information and all the build scripts are in place/nicely standardized.

This PR just makes the necessary updates to make all the services (except condor-log-monitor because we aren't even automatically building that any more), facepalm and filetool/porklock, and the UI build with these labels attached.

The end result here looks like:

```
mian@IPC-MCEWEN:~/Source/DE$ docker inspect -f '{{ json .Config.Labels }}' iplant-groups-with-buildenv-version | python -mjson.tool
{
    "org.iplantc.de.buildenv.git-ref": "eb25c4a84c9f3dcae874dbfb39b73ac98f3f05a4",
    "org.iplantc.de.iplant-groups.git-ref": "a61c588224de9fb367f5f6d6a436a31e3e47a6cf",
    "org.iplantc.de.javabase.git-ref": "720fa72ae7da270a52693b8cd62b618f381d8c02"
}

```

If #1 gets merged first, or the metadactyl rename happens, I'll fix this up with the new names, obviously.