### PR TITLE
Change dewey to use a queue named indexing.ENV

### DIFF
--- a/ansible/roles/cfg-service/templates/dewey.properties.j2
+++ b/ansible/roles/cfg-service/templates/dewey.properties.j2
@@ -1,3 +1,5 @@
+dewey.environment-name          = {{ environment_name }}
+
 dewey.amqp.host                 = {{ amqp_broker.host }}
 dewey.amqp.port                 = {{ amqp_broker.port }}
 dewey.amqp.user                 = {{ amqp_user }}

--- a/services/dewey/src/dewey/amq.clj
+++ b/services/dewey/src/dewey/amq.clj
@@ -21,15 +21,15 @@
 
 
 (defn- consume
-  [connection exchange-name exchange-durable exchange-auto-delete topics delivery-fn]
+  [connection queue exchange-name exchange-durable exchange-auto-delete topics delivery-fn]
   (let [channel  (lch/open connection)
-        queue    "indexing"
         consumer (lc/create-default channel
                    :handle-consume-ok-fn (fn [_] (log/info "Registered with AMQP broker"))
                    :handle-delivery-fn   delivery-fn
                    :handle-cancel-fn     (fn [_] (log/info "AMQP broker registration canceled")
                                                  (Thread/sleep 1000)
                                                  (consume connection
+                                                          queue
                                                           exchange-name
                                                           exchange-durable
                                                           exchange-auto-delete
@@ -61,12 +61,13 @@
    Throws:
      It will throw an exception if it fails to connect to the AMQP broker, setup the exchange, or
      setup the queue."
-  [host port user password exchange-name exchange-durable exchange-auto-delete consumer-fn & topics]
+  [host port user password queue-name exchange-name exchange-durable exchange-auto-delete consumer-fn & topics]
   (consume (rmq/connect {:host                  host
                          :port                  port
                          :username              user
                          :password              password
                          :automatically-recover true})
+           queue-name
            exchange-name
            exchange-durable
            exchange-auto-delete

--- a/services/dewey/src/dewey/core.clj
+++ b/services/dewey/src/dewey/core.clj
@@ -53,6 +53,7 @@
                                             (Integer. (get props "dewey.amqp.port"))
                                             (get props "dewey.amqp.user")
                                             (get props "dewey.amqp.password")
+                                            (str "indexing." (get props "dewey.environment_name"))
                                             (get props "dewey.amqp.exchange.name")
                                             (Boolean. (get props "dewey.amqp.exchange.durable"))
                                             (Boolean. (get props "dewey.amqp.exchange.auto-delete"))


### PR DESCRIPTION
ENV refers to a descriptive name for the environment it's running in. This should make it possible to run dewey off the same AMQP instance in two environments (i.e., in parasitic environments) as well as making it more plausible to horizontally scale by spinning up extra instances of dewey.

As far as review, I'd like to know if this breaks something. I don't believe so, because it appears the order messages come in shouldn't matter. But others (@tedgin especially, I believe) may have clearer ideas of edge cases to consider.