### PR TITLE
Update a bunch of notificationagent dependencies.

### DIFF
--- a/services/NotificationAgent/project.clj
+++ b/services/NotificationAgent/project.clj
@@ -14,21 +14,21 @@
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "notificationagent-standalone.jar"
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [cheshire "5.5.0"
                   :exclusions [[com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]
                                [com.fasterxml.jackson.dataformat/jackson-dataformat-smile]
                                [com.fasterxml.jackson.core/jackson-annotations]
                                [com.fasterxml.jackson.core/jackson-databind]
                                [com.fasterxml.jackson.core/jackson-core]]]
-                 [compojure "1.3.1"]
+                 [compojure "1.4.0"]
                  [org.iplantc/clojure-commons "5.2.3.0"]
                  [org.iplantc/kameleon "5.2.3.0"]
                  [org.iplantc/common-cli "5.2.3.0"]
                  [org.iplantc/service-logging "5.2.3.0"]
                  [me.raynes/fs "1.4.6"]
-                 [clj-http "1.0.1"]
-                 [clj-time "0.8.0"]
+                 [clj-http "2.0.0"]
+                 [clj-time "0.11.0"]
                  [slingshot "0.12.1"]
                  [com.mchange/c3p0 "0.9.5.1"]
                  [korma "0.3.2"


### PR DESCRIPTION
It was failing to compile as a result of the compojure-api upgrade, and this set of upgrades seems to result in it actually compiling again.

I'm not completely sure which ones are required and which aren't, but all of them are worth doing; I'd just like a check that there's nothing here which will break everything. Notably I've *not* updated korma, since the change in behavior for `update` would probably require deeper changes.