### PR TITLE
data-info schema annoyances

### DIFF
--- a/services/data-info/src/data_info/routes/data.clj
+++ b/services/data-info/src/data_info/routes/data.clj
@@ -12,7 +12,7 @@
             [data-info.util.config :as cfg]
             [clojure-commons.error-codes :as ce]
             [data-info.util.service :as svc]
-            [schema.core :as s]))
+            [data-info.util.schema :as s]))
 
 (defroutes* data-operations
 
@@ -130,7 +130,7 @@ with characters in a runtime-configurable parameter. Currently, this parameter l
 
       (GET* "/chunks-tabular" [:as {uri :uri}]
         :query [params TabularChunkParams]
-        :return (s/either TabularChunkDoc TabularChunkReturn)
+        :return (s/doc-only TabularChunkReturn TabularChunkDoc)
         :summary "Get Tabular File Chunk"
         :description (str
   "Gets the specified page of the tabular file, with a page size roughly corresponding to the provided size. The size is not precisely guaranteed, because partial lines cannot be correctly parsed."

--- a/services/data-info/src/data_info/routes/domain/data.clj
+++ b/services/data-info/src/data_info/routes/domain/data.clj
@@ -112,7 +112,7 @@
    :chunk      (describe String "The read result.")})
 
 (s/defschema CSVEntry
-  {(describe String "The column number.")
+  {(describe s/Keyword "The column number.")
    (describe String "The column data.")})
 
 (s/defschema CSVDoc

--- a/services/data-info/src/data_info/routes/domain/exists.clj
+++ b/services/data-info/src/data_info/routes/domain/exists.clj
@@ -3,7 +3,7 @@
   (:require [schema.core :as s]))
 
 (s/defschema PathExistenceMap
-  {(describe String "The IRDOS data item's path")
+  {(describe s/Keyword "The IRDOS data item's path")
    (describe Boolean "Whether this path from the request exists")})
 
 (s/defschema ExistenceInfo

--- a/services/data-info/src/data_info/routes/domain/exists.clj
+++ b/services/data-info/src/data_info/routes/domain/exists.clj
@@ -3,7 +3,7 @@
   (:require [schema.core :as s]))
 
 (s/defschema PathExistenceMap
-  {(describe s/Keyword "The IRDOS data item's path")
+  {(describe s/Keyword "The iRODS data item's path")
    (describe Boolean "Whether this path from the request exists")})
 
 (s/defschema ExistenceInfo

--- a/services/data-info/src/data_info/routes/domain/stats.clj
+++ b/services/data-info/src/data_info/routes/domain/stats.clj
@@ -60,7 +60,7 @@
 
 (s/defschema PathsMap
   {(describe s/Keyword "The IRDOS data item's path")
-   (describe (s/either FileStatInfo DirStatInfo) "The data item's info")})
+   (describe (s/conditional #(contains? % :file-size) FileStatInfo :else DirStatInfo) "The data item's info")})
 
 (s/defschema StatusInfo
   {:paths (describe PathsMap "Paths info")})

--- a/services/data-info/src/data_info/routes/domain/stats.clj
+++ b/services/data-info/src/data_info/routes/domain/stats.clj
@@ -59,7 +59,7 @@
   {:file (describe FileStatInfo "File info")})
 
 (s/defschema PathsMap
-  {(describe String "The IRDOS data item's path")
+  {(describe s/Keyword "The IRDOS data item's path")
    (describe (s/either FileStatInfo DirStatInfo) "The data item's info")})
 
 (s/defschema StatusInfo

--- a/services/data-info/src/data_info/routes/domain/stats.clj
+++ b/services/data-info/src/data_info/routes/domain/stats.clj
@@ -59,7 +59,7 @@
   {:file (describe FileStatInfo "File info")})
 
 (s/defschema PathsMap
-  {(describe s/Keyword "The IRDOS data item's path")
+  {(describe s/Keyword "The iRODS data item's path")
    (describe (s/conditional #(contains? % :file-size) FileStatInfo :else DirStatInfo) "The data item's info")})
 
 (s/defschema StatusInfo

--- a/services/data-info/src/data_info/routes/domain/trash.clj
+++ b/services/data-info/src/data_info/routes/domain/trash.clj
@@ -12,7 +12,7 @@
    :partial-restore (describe Boolean "If this file was restored to the home directory rather than to its former location, due to missing metadata.")})
 
 (s/defschema RestorationMap
- {(describe String "The IRODS data item's original path in the trash")
+ {(describe s/Keyword "The IRODS data item's original path in the trash")
   (describe RestoredFile "The restored file information.")})
 
 (s/defschema Restoration

--- a/services/data-info/src/data_info/routes/exists.clj
+++ b/services/data-info/src/data_info/routes/exists.clj
@@ -4,7 +4,7 @@
         [data-info.routes.domain.exists])
   (:require [data-info.services.exists :as exists]
             [data-info.util.service :as svc]
-            [schema.core :as s]))
+            [data-info.util.schema :as s]))
 
 
 (defroutes* existence-marker
@@ -15,7 +15,7 @@
     (POST* "/" [:as {uri :uri}]
       :query [params StandardUserQueryParams]
       :body [body (describe Paths "The paths to check for existence.")]
-      :return (s/either ExistenceResponse ExistenceInfo)
+      :return (s/doc-only ExistenceInfo ExistenceResponse)
       :summary "File and Folder Existence"
       :description (str
 "This endpoint allows the caller to check for the existence of a set of files and folders."

--- a/services/data-info/src/data_info/routes/stats.clj
+++ b/services/data-info/src/data_info/routes/stats.clj
@@ -4,7 +4,7 @@
         [data-info.routes.domain.stats])
   (:require [data-info.services.stat :as stat]
             [data-info.util.service :as svc]
-            [schema.core :as s]))
+            [data-info.util.schema :as s]))
 
 
 (defroutes* stat-gatherer
@@ -17,7 +17,7 @@
     (POST* "/" [:as {uri :uri}]
       :query [params StandardUserQueryParams]
       :body [body (describe Paths "The paths to gather status information on.")]
-      :return (s/either StatResponse StatusInfo)
+      :return (s/doc-only StatusInfo StatResponse)
       :summary "File and Folder Status Information"
       :description (str
 "This endpoint allows the caller to get information about many files and folders at once."

--- a/services/data-info/src/data_info/routes/trash.clj
+++ b/services/data-info/src/data_info/routes/trash.clj
@@ -4,7 +4,7 @@
         [data-info.routes.domain.trash])
   (:require [data-info.services.trash :as trash]
             [data-info.util.service :as svc]
-            [schema.core :as s]))
+            [data-info.util.schema :as s]))
 
 (defroutes* trash
     (DELETE* "/trash" [:as {uri :uri}]
@@ -32,7 +32,7 @@
       :tags ["bulk"]
       :query [params StandardUserQueryParams]
       :body [body (describe OptionalPaths "The paths to restore, or an empty or missing list to restore the whole trash")]
-      :return (s/either RestorationPaths Restoration)
+      :return (s/doc-only Restoration RestorationPaths)
       :summary "Restore Data Items"
       :description (str
   "Restore the data items with the listed paths from the trash to their original locations, or the user home directory if their original location information is not available."

--- a/services/data-info/src/data_info/services/exists.clj
+++ b/services/data-info/src/data_info/services/exists.clj
@@ -18,7 +18,7 @@
   [{user :user} {paths :paths}]
   (with-jargon (cfg/jargon-cfg) [cm]
     (duv/user-exists cm user)
-    {:paths (into {} (map (juxt identity (partial path-exists-for-user? cm user)) (set paths)))}))
+    {:paths (into {} (map (juxt keyword (partial path-exists-for-user? cm user)) (set paths)))}))
 
 (with-pre-hook! #'do-exists
   (fn [params body]

--- a/services/data-info/src/data_info/services/stat.clj
+++ b/services/data-info/src/data_info/services/stat.clj
@@ -95,7 +95,7 @@
     (validators/user-exists cm user)
     (validators/all-paths-exist cm paths)
     (validators/all-paths-readable cm user paths)
-    {:paths (into {} (map (juxt identity (partial path-stat cm user)) paths))}))
+    {:paths (into {} (map (juxt keyword (partial path-stat cm user)) paths))}))
 
 (with-pre-hook! #'do-stat
   (fn [params body]

--- a/services/data-info/src/data_info/util/schema.clj
+++ b/services/data-info/src/data_info/util/schema.clj
@@ -1,0 +1,25 @@
+(ns data-info.util.schema
+  (:require [schema.spec.variant :as variant]
+            [schema.spec.core :as spec :include-macros true]
+            [ring.swagger.json-schema :as rsjs]
+            [schema.core :as s]))
+
+;; This record type acts like the first schema, but acts like the second schema
+;; for the sake of swagger documentation (as controlled by the `extend-protocol`
+;; below).
+
+(defrecord DocOnly [schema-real schema-doc]
+  s/Schema
+  (spec [this]
+    (variant/variant-spec
+     spec/+no-precondition+
+     [{:schema schema-real}]))
+  (explain [this] (list 'doc-only (s/explain schema-real) (s/explain schema-doc))))
+
+(defn doc-only [schema-to-use schema-to-doc]
+  (DocOnly. schema-to-use schema-to-doc))
+
+(extend-protocol rsjs/JsonSchema
+  DocOnly
+  (convert [e _]
+    (rsjs/->swagger (:schema-doc e))))


### PR DESCRIPTION
This introduces a new DocOnly record type (and associated doc-only helper function) which allows us to get what we were actually using s/either for, i.e., having one thing for swagger documentation and something else entirely for actual schema use. It also fixes some other bits to work correctly, though there may still be pieces of documentation which do not work as expected.

I also, first, reverted my changes to String from s/Keyword, since those broke swagger docs.

Further commentary inline.