### PR TITLE
CORE-7370: modify all JVM services to have descriptive process names

### DIFF
--- a/ansible/roles/de-jex/tasks/main.yaml
+++ b/ansible/roles/de-jex/tasks/main.yaml
@@ -46,10 +46,15 @@
     - jex
     - docker_pull
 
+- name: create /usr/local/bin/jex
+  sudo: yes
+  template: dest=/usr/local/bin/jex src=jex.j2 mode=0755
+  tags:
+    - jex
+    - docker_pull
+
 - name: ensure that /etc/iplant/de exists
   file: path={{ de_config_dir }} state=directory mode=0755
   tags:
     - jex
     - config
-
-

--- a/ansible/roles/de-jex/templates/jex.j2
+++ b/ansible/roles/de-jex/templates/jex.j2
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+exec -a jex /etc/alternatives/java_sdk/bin/java "$@"

--- a/ansible/roles/util-cfg-systemd-unit/templates/jex.service.j2
+++ b/ansible/roles/util-cfg-systemd-unit/templates/jex.service.j2
@@ -4,7 +4,7 @@ Wants=condor.service
 
 [Service]
 User=condor
-ExecStart=/usr/bin/java -cp /usr/local/lib/jex/jex-standalone.jar:/usr/local/lib/jex/ jex.core --config {{ de_config_dir }}/jex.properties
+ExecStart=/usr/local/bin/jex -cp /usr/local/lib/jex/jex-standalone.jar:/usr/local/lib/jex/ jex.core --config {{ de_config_dir }}/jex.properties
 Restart=on-failure
 StartLimitInterval=60s
 StartLimitBurst=3

--- a/docker/javabase/Dockerfile
+++ b/docker/javabase/Dockerfile
@@ -16,6 +16,7 @@ RUN mkdir -p /home/iplant
 RUN busybox adduser -s /bin/sh -u 1337 -D -h /home/iplant iplant
 
 USER iplant
-RUN mkdir -p /home/iplant/logs/
+RUN mkdir -p /home/iplant/logs/ /home/iplant/bin/
 WORKDIR /home/iplant
+ENV PATH /home/iplant/bin:${PATH}
 EXPOSE 60000

--- a/services/Infosquito/Dockerfile
+++ b/services/Infosquito/Dockerfile
@@ -15,5 +15,6 @@ LABEL org.iplantc.de.infosquito.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/infosquito-logging.xml", "-cp", ".:infosquito-standalone.jar", "infosquito.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/infosquito"
+ENTRYPOINT ["infosquito", "-Dlogback.configurationFile=/etc/iplant/de/logging/infosquito-logging.xml", "-cp", ".:infosquito-standalone.jar", "infosquito.core"]
 CMD ["--help"]

--- a/services/NotificationAgent/Dockerfile
+++ b/services/NotificationAgent/Dockerfile
@@ -15,5 +15,6 @@ LABEL org.iplantc.de.notificationagent.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/notificationagent-logging.xml", "-cp", ".:notificationagent-standalone.jar", "notification_agent.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/notificationagent"
+ENTRYPOINT ["notificationagent", "-Dlogback.configurationFile=/etc/iplant/de/logging/notificationagent-logging.xml", "-cp", ".:notificationagent-standalone.jar", "notification_agent.core"]
 CMD ["--help"]

--- a/services/anon-files/Dockerfile
+++ b/services/anon-files/Dockerfile
@@ -15,4 +15,5 @@ LABEL org.iplantc.de.anon-files.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/anon-files-logging.xml", "-cp", ".:anon-files-standalone.jar", "anon_files.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/anon-files"
+ENTRYPOINT ["anon-files", "-Dlogback.configurationFile=/etc/iplant/de/logging/anon-files-logging.xml", "-cp", ".:anon-files-standalone.jar", "anon_files.core"]

--- a/services/apps/Dockerfile
+++ b/services/apps/Dockerfile
@@ -22,5 +22,6 @@ LABEL org.iplantc.de.apps.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/apps-logging.xml", "-cp", ".:apps-standalone.jar:/home/iplant/", "apps.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/apps"
+ENTRYPOINT ["apps", "-Dlogback.configurationFile=/etc/iplant/de/logging/apps-logging.xml", "-cp", ".:apps-standalone.jar:/home/iplant/", "apps.core"]
 CMD ["--help"]

--- a/services/clockwork/Dockerfile
+++ b/services/clockwork/Dockerfile
@@ -15,4 +15,5 @@ LABEL org.iplantc.de.clockwork.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/clockwork-logging.xml", "-cp", ".:clockwork-standalone.jar", "clockwork.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/clockwork"
+ENTRYPOINT ["clockwork", "-Dlogback.configurationFile=/etc/iplant/de/logging/clockwork-logging.xml", "-cp", ".:clockwork-standalone.jar", "clockwork.core"]

--- a/services/data-info/Dockerfile
+++ b/services/data-info/Dockerfile
@@ -15,5 +15,6 @@ LABEL org.iplantc.de.data-info.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/data-info-logging.xml", "-cp", ".:data-info-standalone.jar", "data_info.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/data-info"
+ENTRYPOINT ["data-info", "-Dlogback.configurationFile=/etc/iplant/de/logging/data-info-logging.xml", "-cp", ".:data-info-standalone.jar", "data_info.core"]
 CMD ["--help"]

--- a/services/dewey/Dockerfile
+++ b/services/dewey/Dockerfile
@@ -15,5 +15,6 @@ LABEL org.iplantc.de.dewey.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/dewey-logging.xml", "-cp", ".:dewey-standalone.jar", "dewey.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/dewey"
+ENTRYPOINT ["dewey", "-Dlogback.configurationFile=/etc/iplant/de/logging/dewey-logging.xml", "-cp", ".:dewey-standalone.jar", "dewey.core"]
 CMD ["--help"]

--- a/services/info-typer/Dockerfile
+++ b/services/info-typer/Dockerfile
@@ -15,5 +15,6 @@ LABEL org.iplantc.de.info-typer.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/info-typer-logging.xml", "-cp", ".:info-typer-standalone.jar", "info_typer.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/info-typer"
+ENTRYPOINT ["info-typer", "-Dlogback.configurationFile=/etc/iplant/de/logging/info-typer-logging.xml", "-cp", ".:info-typer-standalone.jar", "info_typer.core"]
 CMD ["--help"]

--- a/services/iplant-email/Dockerfile
+++ b/services/iplant-email/Dockerfile
@@ -16,5 +16,6 @@ LABEL org.iplantc.de.iplant-email.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/iplant-email-logging.xml", "-cp", ".:iplant-email-standalone.jar", "iplant_email.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/iplant-email"
+ENTRYPOINT ["iplant-email", "-Dlogback.configurationFile=/etc/iplant/de/logging/iplant-email-logging.xml", "-cp", ".:iplant-email-standalone.jar", "iplant_email.core"]
 CMD ["--help"]

--- a/services/iplant-groups/Dockerfile
+++ b/services/iplant-groups/Dockerfile
@@ -15,5 +15,6 @@ LABEL org.iplantc.de.iplant-groups.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/iplant-groups-logging.xml", "-cp", ".:iplant-groups-standalone.jar:/home/iplant/", "iplant_groups.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/iplant-groups"
+ENTRYPOINT ["iplant-groups", "-Dlogback.configurationFile=/etc/iplant/de/logging/iplant-groups-logging.xml", "-cp", ".:iplant-groups-standalone.jar:/home/iplant/", "iplant_groups.core"]
 CMD ["--help"]

--- a/services/kifshare/Dockerfile
+++ b/services/kifshare/Dockerfile
@@ -16,5 +16,6 @@ LABEL org.iplantc.de.kifshare.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/kifshare-logging.xml", "-cp", ".:resources:kifshare-standalone.jar", "kifshare.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/kifshare"
+ENTRYPOINT ["kifshare", "-Dlogback.configurationFile=/etc/iplant/de/logging/kifshare-logging.xml", "-cp", ".:resources:kifshare-standalone.jar", "kifshare.core"]
 CMD ["--help"]

--- a/services/metadata/Dockerfile
+++ b/services/metadata/Dockerfile
@@ -15,5 +15,6 @@ LABEL org.iplantc.de.metadata.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/metadata-logging.xml", "-cp", ".:metadata-standalone.jar:/home/iplant/", "metadata.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/metadata"
+ENTRYPOINT ["metadata", "-Dlogback.configurationFile=/etc/iplant/de/logging/metadata-logging.xml", "-cp", ".:metadata-standalone.jar:/home/iplant/", "metadata.core"]
 CMD ["--help"]

--- a/services/monkey/Dockerfile
+++ b/services/monkey/Dockerfile
@@ -15,5 +15,6 @@ LABEL org.iplantc.de.monkey.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/monkey-logging.xml", "-cp", ".:monkey-standalone.jar", "monkey.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/monkey"
+ENTRYPOINT ["monkey", "-Dlogback.configurationFile=/etc/iplant/de/logging/monkey-logging.xml", "-cp", ".:monkey-standalone.jar", "monkey.core"]
 CMD ["--help"]

--- a/services/saved-searches/Dockerfile
+++ b/services/saved-searches/Dockerfile
@@ -15,5 +15,6 @@ LABEL org.iplantc.de.saved-searches.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/saved-searches-logging.xml", "-cp", ".:saved-searches-standalone.jar", "saved_searches.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/saved-searches"
+ENTRYPOINT ["saved-searches", "-Dlogback.configurationFile=/etc/iplant/de/logging/saved-searches-logging.xml", "-cp", ".:saved-searches-standalone.jar", "saved_searches.core"]
 CMD ["--help"]

--- a/services/terrain/Dockerfile
+++ b/services/terrain/Dockerfile
@@ -22,5 +22,6 @@ LABEL org.iplantc.de.terrain.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/terrain-logging.xml", "-cp", ".:terrain-standalone.jar", "terrain.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/terrain"
+ENTRYPOINT ["terrain", "-Dlogback.configurationFile=/etc/iplant/de/logging/terrain-logging.xml", "-cp", ".:terrain-standalone.jar", "terrain.core"]
 CMD ["--help"]

--- a/services/tree-urls/Dockerfile
+++ b/services/tree-urls/Dockerfile
@@ -15,5 +15,6 @@ LABEL org.iplantc.de.tree-urls.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/tree-urls-logging.xml", "-cp", ".:tree-urls-standalone.jar", "tree_urls.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/tree-urls"
+ENTRYPOINT ["tree-urls", "-Dlogback.configurationFile=/etc/iplant/de/logging/tree-urls-logging.xml", "-cp", ".:tree-urls-standalone.jar", "tree_urls.core"]
 CMD ["--help"]

--- a/services/user-preferences/Dockerfile
+++ b/services/user-preferences/Dockerfile
@@ -15,5 +15,6 @@ LABEL org.iplantc.de.user-preferences.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/user-preferences-logging.xml", "-cp", ".:user-preferences-standalone.jar", "user_preferences.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/user-preferences"
+ENTRYPOINT ["user-preferences", "-Dlogback.configurationFile=/etc/iplant/de/logging/user-preferences-logging.xml", "-cp", ".:user-preferences-standalone.jar", "user_preferences.core"]
 CMD ["--help"]

--- a/services/user-sessions/Dockerfile
+++ b/services/user-sessions/Dockerfile
@@ -15,5 +15,6 @@ LABEL org.iplantc.de.user-sessions.git-ref="$git_commit" \
       org.iplantc.de.buildenv.git-ref="$buildenv_git_commit"
 
 USER iplant
-ENTRYPOINT ["java", "-Dlogback.configurationFile=/etc/iplant/de/logging/user-sessions-logging.xml", "-cp", ".:user-sessions-standalone.jar", "user_sessions.core"]
+RUN ln -s "/opt/jdk/bin/java" "/home/iplant/bin/user-sessions"
+ENTRYPOINT ["user-sessions", "-Dlogback.configurationFile=/etc/iplant/de/logging/user-sessions-logging.xml", "-cp", ".:user-sessions-standalone.jar", "user_sessions.core"]
 CMD ["--help"]


### PR DESCRIPTION
This turned out to be a lot simpler than I expected because the JDK version of the `java` executable (as opposed to the JRE version) doesn't re-execute the command. Because of this, we can use a symbolic link to change the process name of all of our JVM services that run in Docker containers.

The JEX was a little bit different because it doesn't run in a container. This was also relatively simple however. This change involved creating a bash wrapper script that uses `exec -a` to set the process name.
